### PR TITLE
Improve unordered list styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -37,6 +37,22 @@ h3 {
   font-family: "Inter", "Poppins", sans-serif;
   font-weight: 600;
 }
+ul:not(.nav-list):not(.footer-nav) {
+  list-style: none;
+  padding-left: 0;
+}
+ul:not(.nav-list):not(.footer-nav) li {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 0.5rem;
+}
+ul:not(.nav-list):not(.footer-nav) li::before {
+  content: "•";
+  color: var(--primary-color);
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
 .container {
   max-width: var(--max-width);
   width: 100%;


### PR DESCRIPTION
## Summary
- remove default bullets and padding for general lists
- add custom bullet markers with primary color and bold weight
- apply spacing between list items for better readability

## Testing
- `tidy -errors sitemap.html`
- `tidy -errors about.html`


------
https://chatgpt.com/codex/tasks/task_e_6849d912f7cc832f9af84a84afd34478